### PR TITLE
Fix CI Build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .vscode
-
+.vs
+**/bin
+**/obj

--- a/example/MyFirstKubewardenPolicy.Tests/MyFirstKubewardenPolicy.Tests.csproj
+++ b/example/MyFirstKubewardenPolicy.Tests/MyFirstKubewardenPolicy.Tests.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="KubernetesClient.Models" Version="12.0.16" />
+    <PackageReference Include="KubernetesClient" Version="14.0.9" />
     <ProjectReference Include="..\MyFirstKubewardenPolicy\MyFirstKubewardenPolicy.csproj" />
     <ProjectReference Include="..\..\src\KubewardenPolicySDK\KubewardenPolicySDK.csproj" />
   </ItemGroup>

--- a/example/MyFirstKubewardenPolicy/MyFirstKubewardenPolicy.csproj
+++ b/example/MyFirstKubewardenPolicy/MyFirstKubewardenPolicy.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="KubernetesClient.Models" Version="12.0.16" />
+    <PackageReference Include="KubernetesClient" Version="14.0.9" />
     <PackageReference Include="WapcGuest" Version="0.1.1" />
     <PackageReference Include="Wasi.Sdk" Version="0.1.1" />
 

--- a/example/MyFirstKubewardenPolicy/MyFirstKubewardenPolicy.csproj
+++ b/example/MyFirstKubewardenPolicy/MyFirstKubewardenPolicy.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <WasiTrim>true</WasiTrim>
+    <WasiTrim>false</WasiTrim>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
KubernetesClient.Models is deprecated in favor of just KubernetesClient, this should fix the "Type exists in Both" error.

WasiTrim may still need disabled, but I'm not certain.

## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix #34 

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

Just allow the CI Build to run and validate
