### PR TITLE
solve problem of compatability of KubernetesClient version 16.0.2

### DIFF
--- a/example/MyFirstKubewardenPolicy.Tests/MyFirstKubewardenPolicy.Tests.csproj
+++ b/example/MyFirstKubewardenPolicy.Tests/MyFirstKubewardenPolicy.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/example/MyFirstKubewardenPolicy/Makefile
+++ b/example/MyFirstKubewardenPolicy/Makefile
@@ -1,8 +1,8 @@
-bin/Release/net7.0/MyFirstKubewardenPolicy.wasm: MyFirstKubewardenPolicy.csproj *.cs
+bin/Release/net8.0/MyFirstKubewardenPolicy.wasm: MyFirstKubewardenPolicy.csproj *.cs
 	dotnet build -c Release
 
-annotated-policy.wasm: bin/Release/net7.0/MyFirstKubewardenPolicy.wasm
-	kwctl annotate -m metadata.yml -o annotated-policy.wasm bin/Release/net7.0/MyFirstKubewardenPolicy.wasm
+annotated-policy.wasm: bin/Release/net8.0/MyFirstKubewardenPolicy.wasm
+	kwctl annotate -m metadata.yml -o annotated-policy.wasm bin/Release/net8.0/MyFirstKubewardenPolicy.wasm
 
 .PHONY: e2e-tests
 e2e-tests: annotated-policy.wasm

--- a/example/MyFirstKubewardenPolicy/MyFirstKubewardenPolicy.csproj
+++ b/example/MyFirstKubewardenPolicy/MyFirstKubewardenPolicy.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <WasiTrim>false</WasiTrim>
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="KubernetesClient" Version="16.0.2" />
+    <PackageReference Include="System.Runtime" Version="4.3.1" />
     <PackageReference Include="WapcGuest" Version="0.1.1" />
     <PackageReference Include="Wasi.Sdk" Version="0.1.1" />
 


### PR DESCRIPTION
## Description

solve problem of compatibility of `KubernetesClient` version 16.0.2

Fixing : https://github.com/kubewarden/policy-sdk-dotnet/pull/43

- The new version of `KubernetesClient` `v16.0.2` do not work with `.net7` it needes at least `.net8`, that was mentioned in `README.md` of `KubernetesClient` here https://github.com/kubernetes-client/csharp#version-compatibility
- So I updated the examples projects to run on `.net8`.

- I think we still have problems when updating the SDK itself to `.net8` it gives problems when try to run e2e tests.
     - So I used SDK targeting `.net7`.
- I tried unit-tests and e2e tests and works partially well.
- I think you will need to update the CI to  test using `.net8`
